### PR TITLE
Fixing 'first' node affecting code structure

### DIFF
--- a/examples/Button.qf
+++ b/examples/Button.qf
@@ -8,7 +8,7 @@
         "Exit"
     }
     Button{
-        "arg3",
-        "Nothin"
-    }
+        "Button3",
+        "Exit"
+    }    
 }

--- a/examples/Button.qf
+++ b/examples/Button.qf
@@ -7,8 +7,5 @@
         "Button2",
         "Exit"
     }
-    Button{
-        "Button3",
-        "Exit"
-    }    
+  
 }

--- a/include/quick-ftxui.hpp
+++ b/include/quick-ftxui.hpp
@@ -49,7 +49,7 @@ struct input {
 };
 
 struct expression {
-    std::list<node> rest;
+    std::list<node> expr;
 };
 
 // print function for debugging
@@ -87,7 +87,7 @@ BOOST_FUSION_ADAPT_STRUCT(client::quick_ftxui_ast::input,
 )
 
 BOOST_FUSION_ADAPT_STRUCT(client::quick_ftxui_ast::expression,
-                          (std::list<client::quick_ftxui_ast::node>, rest)
+                          (std::list<client::quick_ftxui_ast::node>, expr)
 )
 
 // clang-format on
@@ -161,7 +161,7 @@ void ast_printer::operator()(
               << "Node" << std::endl;
     std::cout << '{' << std::endl;
 
-    for (quick_ftxui_ast::node const &node : expr.rest) {
+    for (quick_ftxui_ast::node const &node : expr.expr) {
         boost::apply_visitor(node_printer(data, indent), node);
     }
 

--- a/include/quick-ftxui.hpp
+++ b/include/quick-ftxui.hpp
@@ -49,7 +49,6 @@ struct input {
 };
 
 struct expression {
-    button first;
     std::list<node> rest;
 };
 
@@ -88,7 +87,6 @@ BOOST_FUSION_ADAPT_STRUCT(client::quick_ftxui_ast::input,
 )
 
 BOOST_FUSION_ADAPT_STRUCT(client::quick_ftxui_ast::expression,
-                          (client::quick_ftxui_ast::button, first)
                           (std::list<client::quick_ftxui_ast::node>, rest)
 )
 
@@ -162,7 +160,6 @@ void ast_printer::operator()(
     std::cout << "tag: "
               << "Node" << std::endl;
     std::cout << '{' << std::endl;
-    node_printer(data, indent).operator()(expr.first);
 
     for (quick_ftxui_ast::node const &node : expr.rest) {
         boost::apply_visitor(node_printer(data, indent), node);
@@ -215,7 +212,7 @@ struct parser
 
         node = button_comp | input_comp | expression;
 
-        expression = '{' >> button_comp >> *node >> '}';
+        expression = '{' >> *node >> '}';
 
         // Debugging and error handling and reporting support.
         BOOST_SPIRIT_DEBUG_NODES((button_comp)(expression));

--- a/tests/test1.cpp
+++ b/tests/test1.cpp
@@ -37,6 +37,13 @@ TEST_CASE("Parse Complex") {
         }"));
 }
 
+TEST_CASE("Parse Multiple in any order") {
+    REQUIRE(parse_helper("{\
+        Input{\"amool\" , \"bmpp\", \"cmqq\"}  \
+        Button{\"amool\" , \"bmpp\"}\
+        }"));
+}
+
 TEST_CASE("Parse Recursive") {
     // expect pass
     REQUIRE(parse_helper("{\


### PR DESCRIPTION
Removed code structure's dependency on the order in which the components are to be rendered
Fixes - https://github.com/SAtacker/quick-ftxui/issues/2#issue-1571396859